### PR TITLE
build_node_compilers 0.1.0+1: Use `--use-old-frontend` with `dart2js1 as temp fix

### DIFF
--- a/build_node_compilers/CHANGELOG.md
+++ b/build_node_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.0+1
+
+- Use `--use-old-frontend` with `dart2js` as a stopgap until we can add support
+  for `.packages` files.
+
 # 0.1.0
 
 - Initial version based on `build_web_compilers`.

--- a/build_node_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_node_compilers/lib/src/dart2js_bootstrap.dart
@@ -27,6 +27,7 @@ Future<Null> bootstrapDart2Js(
   var args = dart2JsArgs.toList()
     ..addAll([
       '-ppackages',
+      '--use-old-frontend',
       '-o${jsOutputId.path}',
       dartEntrypointId.path,
     ]);

--- a/build_node_compilers/pubspec.yaml
+++ b/build_node_compilers/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_node_compilers
-version: 0.1.0
+version: 0.1.0+1
 description: Builders wrapping DDC and dart2js compilers configured to output Node modules
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: '>=2.0.0-dev <2.0.0'
+  sdk: '>=2.0.0-dev.37 <2.0.0'
 
 dependencies:
   analyzer: ^0.30.0


### PR DESCRIPTION
https://github.com/dart-lang/build/pull/1172/files