### PR TITLE
Remove `test/**_test.dart` from the default globs

### DIFF
--- a/build_node_compilers/build.yaml
+++ b/build_node_compilers/build.yaml
@@ -26,5 +26,5 @@ builders:
     auto_apply: root_package
     defaults:
       generate_for:
-        include: ["node/**", "example/**", "test/**_test.dart", "test/**.node_test.dart"]
+        include: ["node/**", "example/**", "test/**.node_test.dart"]
         exclude: ["test/**.vm_test.dart"]


### PR DESCRIPTION
See https://github.com/dart-lang/test/issues/862 for context - I don't know that there is a reason to bootstrap these files with node?