### PR TITLE
Rename platforms and extensions to avoid conflicts

### DIFF
--- a/build_node_compilers/CHANGELOG.md
+++ b/build_node_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.4
+
+- Fixed platform names and file extensions conflicting with build_web_compilers.
+
 # 0.2.3
 
 - Fix: Added node_io to list of known packages that can skip platform checks when compiled with

--- a/build_node_compilers/build.yaml
+++ b/build_node_compilers/build.yaml
@@ -20,10 +20,10 @@ builders:
       - dart2jsModuleBuilder
     build_extensions:
       $lib$:
-        - .dart2js.meta_module.raw
-        - .dart2js.meta_module.clean
+        - .dart2js_node.meta_module.raw
+        - .dart2js_node.meta_module.clean
       .dart:
-        - .dart2js.module
+        - .dart2js_node.module
     is_optional: True
     auto_apply: none
     required_inputs: [".dart", ".module.library"]
@@ -36,10 +36,10 @@ builders:
       - ddcModuleBuilder
     build_extensions:
       $lib$:
-        - .ddc.meta_module.raw
-        - .ddc.meta_module.clean
+        - .ddc_node.meta_module.raw
+        - .ddc_node.meta_module.clean
       .dart:
-        - .ddc.module
+        - .ddc_node.module
     is_optional: True
     auto_apply: none
     required_inputs: [".dart", ".module.library"]
@@ -50,15 +50,15 @@ builders:
       - ddcKernelBuilder
       - ddcBuilder
     build_extensions:
-      .ddc.module:
-        - .node.ddc.dill
-        - .node.ddc.js.errors
-        - .node.ddc.js
-        - .node.ddc.js.map
+      .ddc_node.module:
+        - .ddc_node.dill
+        - .ddc_node.js.errors
+        - .ddc_node.js
+        - .ddc_node.js.map
     is_optional: True
     auto_apply: all_packages
     required_inputs:
-      - .ddc.module
+      - .ddc_node.module
     applies_builders:
       - build_node_compilers|ddc_modules
       # This isn't really the best place to apply these, but it is the only
@@ -77,9 +77,9 @@ builders:
         - .digests
     required_inputs:
       - .dart
-      - .node.ddc.js
-      - .ddc.module
-      - .dart2js.module
+      - .ddc_node.js
+      - .ddc_node.module
+      - .dart2js_node.module
     build_to: cache
     auto_apply: root_package
     defaults:

--- a/build_node_compilers/lib/builders.dart
+++ b/build_node_compilers/lib/builders.dart
@@ -25,12 +25,13 @@ Builder ddcBuilder(BuilderOptions options) => DevCompilerBuilder(
       useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
       platform: ddcPlatform,
     );
-const ddcKernelExtension = '.ddc.dill';
+const ddcKernelExtension = '.ddc_node.dill';
 Builder ddcKernelBuilder(BuilderOptions options) => KernelBuilder(
     summaryOnly: true,
     sdkKernelPath: p.url.join('lib', '_internal', 'ddc_sdk.dill'),
     outputExtension: ddcKernelExtension,
     platform: ddcPlatform,
+    kernelTargetName: 'ddc', // otherwise kernel_worker fails on unknown target
     useIncrementalCompiler: _readUseIncrementalCompilerOption(options));
 //Builder sdkJsCopyBuilder(_) => SdkJsCopyBuilder();
 PostProcessBuilder sdkJsCleanupBuilder(BuilderOptions options) =>
@@ -61,7 +62,7 @@ bool _readUseIncrementalCompilerOption(BuilderOptions options) {
   if (_previousDdcConfig != null) {
     if (!const MapEquality().equals(_previousDdcConfig, options.config)) {
       throw ArgumentError(
-          'The build_web_compilers:ddc builder must have the same '
+          'The build_node_compilers:ddc builder must have the same '
           'configuration in all packages. Saw $_previousDdcConfig and '
           '${options.config} which are not equal.\n\n '
           'Please use the `global_options` section in '
@@ -71,7 +72,7 @@ bool _readUseIncrementalCompilerOption(BuilderOptions options) {
     _previousDdcConfig = options.config;
   }
   validateOptions(options.config, [_useIncrementalCompilerOption],
-      'build_web_compilers:ddc');
+      'build_node_compilers:ddc');
   return options.config[_useIncrementalCompilerOption] as bool ?? true;
 }
 

--- a/build_node_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_node_compilers/lib/src/dev_compiler_builder.dart
@@ -16,9 +16,9 @@ import '../builders.dart';
 import 'common.dart';
 import 'errors.dart';
 
-const jsModuleErrorsExtension = '.node.ddc.js.errors';
-const jsModuleExtension = '.node.ddc.js';
-const jsSourceMapExtension = '.node.ddc.js.map';
+const jsModuleErrorsExtension = '.ddc_node.js.errors';
+const jsModuleExtension = '.ddc_node.js';
+const jsSourceMapExtension = '.ddc_node.js.map';
 
 /// A builder which can output ddc modules!
 class DevCompilerBuilder implements Builder {

--- a/build_node_compilers/lib/src/platforms.dart
+++ b/build_node_compilers/lib/src/platforms.dart
@@ -4,7 +4,7 @@
 
 import 'package:build_modules/build_modules.dart';
 
-final ddcPlatform = DartPlatform.register('ddc', [
+final ddcPlatform = DartPlatform.register('ddc_node', [
   'async',
   'collection',
   'convert',
@@ -24,7 +24,7 @@ final ddcPlatform = DartPlatform.register('ddc', [
   '_internal',
 ]);
 
-final dart2jsPlatform = DartPlatform.register('dart2js', [
+final dart2jsPlatform = DartPlatform.register('dart2js_node', [
   'async',
   'collection',
   'convert',

--- a/build_node_compilers/pubspec.yaml
+++ b/build_node_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_node_compilers
-version: 0.2.3
+version: 0.2.4
 description: Builders wrapping DDC and dart2js compilers configured to output Node modules.
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>

--- a/build_node_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_node_compilers/test/dev_compiler_bootstrap_test.dart
@@ -40,10 +40,10 @@ main() {
       'a|web/index.dart.js.map': anything,
       'a|web/index.dart.bootstrap.js': decodedMatches(allOf([
         // Maps non-lib modules to remove the top level dir.
-        contains('"web/index": "index.node.ddc"'),
+        contains('"web/index": "index.ddc_node"'),
         // Maps lib modules to packages path
-        contains('"packages/a/a": "packages/a/a.node.ddc"'),
-        contains('"packages/b/b": "packages/b/b.node.ddc"'),
+        contains('"packages/a/a": "packages/a/a.ddc_node"'),
+        contains('"packages/b/b": "packages/b/b.ddc_node"'),
         // Requires the top level module and dart sdk.
         contains("var Module = require('module');"),
         contains('const dart_sdk = require("dart_sdk");'),


### PR DESCRIPTION
When `build_node_compilers` and `build_web_compilers` are used in the same package, duplicated platform names and file extensions cause conflicts. This PR renames them.

See https://github.com/dart-lang/build/issues/2529.

/cc @jakemac53 