### PR TITLE
Allow node_io compilation on dart 2.8

### DIFF
--- a/node_io/lib/src/http_headers.dart
+++ b/node_io/lib/src/http_headers.dart
@@ -271,11 +271,17 @@ abstract class HttpHeaders implements io.HttpHeaders {
   }
 
   @override
-  void add(String name, Object value) {
-    List<String> existingValues = this[name];
-    var values = existingValues != null ? List.from(existingValues) : [];
-    values.add(value.toString());
-    _setHeader(name, values);
+  void add(String name, Object value, {bool preserveHeaderCase = false}) {
+    if (preserveHeaderCase ?? false) {
+      // new since 2.8
+      // not supported on node
+      throw UnsupportedError('HttpHeaders.add(preserveHeaderCase: true)');
+    } else {
+      List<String> existingValues = this[name];
+      var values = existingValues != null ? List.from(existingValues) : [];
+      values.add(value.toString());
+      _setHeader(name, values);
+    }
   }
 
   @override
@@ -312,7 +318,13 @@ abstract class HttpHeaders implements io.HttpHeaders {
   }
 
   @override
-  void set(String name, Object value) {
-    _setHeader(name, jsify(value));
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
+    if (preserveHeaderCase ?? false) {
+      // new since 2.8
+      // not supported on node
+      throw UnsupportedError('HttpHeaders.add(preserveHeaderCase: true)');
+    } else {
+      _setHeader(name, jsify(value));
+    }
   }
 }

--- a/node_io/pubspec.yaml
+++ b/node_io/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.8.0-0 <3.0.0'
 
 dependencies:
   node_interop: ^1.0.1

--- a/node_io/test/http_server_test.dart
+++ b/node_io/test/http_server_test.dart
@@ -69,13 +69,11 @@ void main() {
       final response =
           await makeGet(Uri.parse('http://127.0.0.1:8181/headers_add_set'));
       final headers = Map<String, dynamic>.from(dartify(response.headers));
-      print(headers);
       expect(headers['add_no_case'], 'test1, test2');
       expect(headers['add_No_case'], isNull);
       expect(headers['set_no_case'], 'test2');
       expect(headers['set_No_case'], isNull);
-      //expect(headers['location'], 'http://127.0.0.1:8181/redirect-success');
-    }, solo: true);
+    });
   });
 }
 


### PR DESCRIPTION
Addresses issue https://github.com/pulyaevskiy/node-interop/issues/74 in the most basic way but at least compile on 2.8