### PR TITLE
Fix improper types for utils

### DIFF
--- a/node_interop/CHANGELOG.md
+++ b/node_interop/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+- Fix improper types for `util.callbackToCompleter()`, `util.invokeAsync0()`,
+  and `util.invokeAsync1()`.
+
 ## 2.0.0
 
 - Enable null-safety (requires \>=Dart 2.12).

--- a/node_interop/lib/util.dart
+++ b/node_interop/lib/util.dart
@@ -113,7 +113,7 @@ Promise futureToPromise<T>(Future<T> future) {
 /// Returns a function that can be passed to a Node.js-style asynchronous
 /// callback that will complete [completer] with that callback's error or
 /// success result.
-void Function(Object, T) callbackToCompleter<T>(Completer<T> completer) {
+void Function(Object?, T) callbackToCompleter<T>(Completer<T> completer) {
   return allowInterop((Object? error, [T? value]) {
     if (error != null) {
       completer.completeError(error);
@@ -125,7 +125,7 @@ void Function(Object, T) callbackToCompleter<T>(Completer<T> completer) {
 
 /// Invokes a zero-argument Node.js-style asynchronous function and encapsulates
 /// the result in a `Future`.
-Future<T> invokeAsync0<T>(void Function(void Function(Object, T)) function) {
+Future<T> invokeAsync0<T>(void Function(void Function(Object?, T)) function) {
   var completer = Completer<T>();
   function(callbackToCompleter(completer));
   return completer.future;
@@ -134,7 +134,7 @@ Future<T> invokeAsync0<T>(void Function(void Function(Object, T)) function) {
 /// Invokes a single-argument Node.js-style asynchronous function and
 /// encapsulates the result in a `Future`.
 Future<T> invokeAsync1<S, T>(
-    void Function(S, void Function(Object, T)) function, S arg1) {
+    void Function(S, void Function(Object?, T)) function, S arg1) {
   var completer = Completer<T>();
   function(arg1, callbackToCompleter(completer));
   return completer.future;

--- a/node_interop/pubspec.yaml
+++ b/node_interop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: node_interop
 description: Provides Dart bindings and utility functions for core Node.js modules.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 


### PR DESCRIPTION
These functions are designed to take in a Node-style callback, with the error as the first argument. Since it will be null when there's no error, it should be typed as `Object?`, not `Object`.