### PR TITLE
Support recursive in File and Directory methods

### DIFF
--- a/node_io/CHANGELOG.md
+++ b/node_io/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.0
+
+- Support the `recursive` option for `File` and `Directory` methods.
+
+- Properly support `followLinks` in `Directory.list` and `Directory.listSync`.
+  The previous behavior always treated `followLinks` as false (even though the
+  actual Dart default is true).
+
 ## 2.0.0
 
 - Enable null-safety (requires Dart >=2.12).

--- a/node_io/lib/src/link.dart
+++ b/node_io/lib/src/link.dart
@@ -52,9 +52,9 @@ class Link extends FileSystemEntity implements file.Link {
   String get _absolutePath => node_path.path.resolve(path);
 
   @override
-  Future<Link> create(String target, {bool recursive = false}) {
+  Future<Link> create(String target, {bool recursive = false}) async {
     if (recursive) {
-      throw UnsupportedError('Recursive flag not supported by Node.js');
+      await parent.create(recursive: true);
     }
 
     final completer = Completer<Link>();
@@ -73,9 +73,7 @@ class Link extends FileSystemEntity implements file.Link {
 
   @override
   void createSync(String target, {bool recursive = false}) {
-    if (recursive) {
-      throw UnsupportedError('Recursive flag not supported by Node.js');
-    }
+    if (recursive) parent.createSync(recursive: true);
     fs.symlinkSync(target, path);
   }
 

--- a/node_io/pubspec.yaml
+++ b/node_io/pubspec.yaml
@@ -1,6 +1,6 @@
 name: node_io
 description: Like dart:io but with Node.js.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   file: ^6.1.0
-  node_interop: ^2.0.1
+  node_interop: ^2.0.2
   path: ^1.8.0
 
 dev_dependencies:
@@ -19,3 +19,4 @@ dev_dependencies:
   build_runner: ">=1.10.0 <1.10.2"
   build_node_compilers: ^0.3.0
   build_test: ^1.0.0
+

--- a/node_io/test/directory_test.dart
+++ b/node_io/test/directory_test.dart
@@ -59,17 +59,35 @@ void main() {
     test('list', () async {
       var list = await Directory.current.list().toList();
       expect(_listContainsPath(list, 'pubspec.yaml'), isTrue);
+      expect(_listContainsPath(list, 'lib/node_io.dart'), isFalse);
 
       list = await dir('lib').list().toList();
       expect(_listContainsPath(list, 'node_io.dart'), isTrue);
+      expect(_listContainsPath(list, 'src/directory.dart'), isFalse);
     });
 
-    test('listSync', () async {
+    test('list recursive', () async {
+      var list = await Directory.current.list(recursive: true).toList();
+      expect(_listContainsPath(list, 'pubspec.yaml'), isTrue);
+      expect(_listContainsPath(list, 'lib/node_io.dart'), isTrue);
+      expect(_listContainsPath(list, 'lib/src/directory.dart'), isTrue);
+    });
+
+    test('listSync', () {
       var list = Directory.current.listSync();
       expect(_listContainsPath(list, 'pubspec.yaml'), isTrue);
+      expect(_listContainsPath(list, 'lib/node_io.dart'), isFalse);
 
       list = dir('lib').listSync();
       expect(_listContainsPath(list, 'node_io.dart'), isTrue);
+      expect(_listContainsPath(list, 'src/directory.dart'), isFalse);
+    });
+
+    test('listSync recursive', () {
+      var list = Directory.current.listSync(recursive: true);
+      expect(_listContainsPath(list, 'pubspec.yaml'), isTrue);
+      expect(_listContainsPath(list, 'lib/node_io.dart'), isTrue);
+      expect(_listContainsPath(list, 'lib/src/directory.dart'), isTrue);
     });
 
     test('createTemp', () async {
@@ -90,14 +108,40 @@ void main() {
 
     test('create_delete', () async {
       var directory = dir('delete_dir');
-      try {
-        await directory.delete();
-      } catch (_) {}
-      ;
       await directory.create();
       expect(await directory.exists(), isTrue);
       await directory.delete();
       expect(await directory.exists(), isFalse);
+    });
+
+    test('create_delete recursive', () async {
+      var outer = dir('delete_dir');
+      var inner = dir('delete_dir/inner');
+      await inner.create(recursive: true);
+      expect(await inner.exists(), isTrue);
+      expect(await outer.exists(), isTrue);
+      await outer.delete(recursive: true);
+      expect(await inner.exists(), isFalse);
+      expect(await outer.exists(), isFalse);
+    });
+
+    test('createSync_deleteSync', () {
+      var directory = dir('delete_dir');
+      directory.createSync();
+      expect(directory.existsSync(), isTrue);
+      directory.deleteSync();
+      expect(directory.existsSync(), isFalse);
+    });
+
+    test('createSync_deleteSync recursive', () {
+      var outer = dir('delete_dir');
+      var inner = dir('delete_dir/inner');
+      inner.createSync(recursive: true);
+      expect(inner.existsSync(), isTrue);
+      expect(outer.existsSync(), isTrue);
+      outer.deleteSync(recursive: true);
+      expect(inner.existsSync(), isFalse);
+      expect(outer.existsSync(), isFalse);
     });
 
     test('rename', () async {

--- a/node_io/test/file_test.dart
+++ b/node_io/test/file_test.dart
@@ -138,6 +138,21 @@ void main() {
       await file.delete();
     });
 
+    test('create recursive', () async {
+      var file = File('directory/create.txt');
+      try {
+        await file.delete();
+      } catch (_) {}
+      expect(await file.exists(), isFalse);
+      await file.create(recursive: true);
+      expect(await file.exists(), isTrue);
+
+      // Recursive should allow path to be deleted even if it's a directory.
+      await File('directory').delete(recursive: true);
+      expect(await file.parent.exists(), isFalse);
+      expect(await file.exists(), isFalse);
+    });
+
     test('createSync', () {
       final file = File(join(Directory.systemTemp.path, 'create_sync.txt'));
       if (file.existsSync()) {
@@ -149,6 +164,24 @@ void main() {
       expect(file.existsSync(), isTrue);
 
       file.deleteSync(); // cleanup
+    });
+
+    test('createSync recursive', () {
+      final file =
+          File(join(Directory.systemTemp.path, 'directory/create_sync.txt'));
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+      expect(file.existsSync(), isFalse);
+
+      file.createSync(recursive: true);
+      expect(file.existsSync(), isTrue);
+      expect(file.parent.existsSync(), isTrue);
+
+      // Recursive should allow path to be deleted even if it's a directory.
+      File(file.parent.path).deleteSync(recursive: true);
+      expect(file.parent.existsSync(), isFalse);
+      expect(file.existsSync(), isFalse);
     });
 
     test('read_write_bytes', () async {


### PR DESCRIPTION
This uses Node's built-in support where possible, but `Directory.list` (and `listSync`) are implemented manually since there's no equivalent in Node.