### PR TITLE
Make the first argument to Promise.then() nullable

### DIFF
--- a/node_interop/CHANGELOG.md
+++ b/node_interop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Mark the first argument to `Promise.then()` as nullable.
+
 ## 2.0.2
 
 - Various `fs` APIs now accept options.

--- a/node_interop/lib/js.dart
+++ b/node_interop/lib/js.dart
@@ -16,7 +16,8 @@ abstract class Promise {
       Function(dynamic Function(dynamic value) resolve,
               dynamic Function(dynamic error) reject)
           executor);
-  external Promise then(dynamic Function(dynamic value) onFulfilled,
+
+  external Promise then(dynamic Function(dynamic value)? onFulfilled,
       [dynamic Function(dynamic error) onRejected]);
 }
 

--- a/node_interop/pubspec.yaml
+++ b/node_interop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: node_interop
 description: Provides Dart bindings and utility functions for core Node.js modules.
-version: 2.0.2
+version: 2.1.0
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 


### PR DESCRIPTION
If null is passed for this argument, it defaults to an identity
function. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
for details.