### PR TITLE
Mark the type of undefined as Null

### DIFF
--- a/node_interop/CHANGELOG.md
+++ b/node_interop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Correctly mark the type of the `undefined` getter as `Null`.
+
 ## 2.1.0
 
 - Mark the first argument to `Promise.then()` as nullable.

--- a/node_interop/lib/js.dart
+++ b/node_interop/lib/js.dart
@@ -8,7 +8,7 @@ library node_interop.js;
 import 'package:js/js.dart';
 
 @JS()
-external dynamic get undefined;
+external Null get undefined;
 
 @JS()
 abstract class Promise {

--- a/node_interop/pubspec.yaml
+++ b/node_interop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: node_interop
 description: Provides Dart bindings and utility functions for core Node.js modules.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 


### PR DESCRIPTION
This could potentially break downstream users' typechecking, but since
it's a bug fix and since any static breakages would already be broken
at runtime I think it's fair to release as a patch.