### PR TITLE
Update node_io to support Dart 3.4

### DIFF
--- a/node_io/CHANGELOG.md
+++ b/node_io/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.3.0
+
+- Add the new `Platform.lineTerminator` property introduced in Dart 3.1.
+
+- Add the new `Stdout.lineTerminator` property introduced in Dart 3.4.
+
+- Add unimplemented setters for `Stdin.echoMode`, `Stdin.echoNewlineMode`,
+  and `Stdin.lineMode`.
+
 ## 2.2.0
 
 - Support the `exclusive` option for `File.create` and `File.createSync`.

--- a/node_io/lib/src/platform.dart
+++ b/node_io/lib/src/platform.dart
@@ -67,6 +67,11 @@ abstract class Platform {
   /// components in file paths.
   static String get pathSeparator => path.sep;
 
+  /// The current operating system's default line terminator.
+  ///
+  /// This is `\n` on all platforms except Windows, where it is `\r\n`.
+  static String get lineTerminator => isWindows ? '\r\n' : '\n';
+
   /// Get the name of the current locale.
   static String get localeName =>
       throw UnsupportedError('Not supported in Node.');

--- a/node_io/lib/src/stdin.dart
+++ b/node_io/lib/src/stdin.dart
@@ -18,11 +18,26 @@ class Stdin extends ReadableStream<List<int>> implements io.Stdin {
   bool get echoMode => throw UnimplementedError('echoMode not supported');
 
   @override
+  set echoMode(bool echoMode) {
+    throw UnimplementedError('echoMode not supported');
+  }
+
+  @override
   bool get echoNewlineMode =>
       throw UnimplementedError('echoNewlineMode not supported');
 
   @override
+  set echoNewlineMode(bool echoNewlineMode) {
+    throw UnimplementedError('echoNewlineMode not supported');
+  }
+
+  @override
   bool get lineMode => throw UnimplementedError('lineMode not supported');
+
+  @override
+  set lineMode(bool lineMode) {
+    throw UnimplementedError('lineMode not supported');
+  }
 
   @override
   bool get hasTerminal => nativeInstance.isTTY;

--- a/node_io/lib/src/stdout.dart
+++ b/node_io/lib/src/stdout.dart
@@ -8,6 +8,9 @@ import 'package:node_interop/tty.dart';
 import 'streams.dart';
 
 class Stdout extends NodeIOSink implements io.Stdout {
+  /// The line terminator used when `writeln` is called.
+  String lineTerminator = '\n';
+
   Stdout(TTYWriteStream nativeStream) : super(nativeStream);
 
   @override
@@ -31,4 +34,9 @@ class Stdout extends NodeIOSink implements io.Stdout {
 
   @override
   int get terminalLines => nativeInstance.rows;
+
+  @override
+  void writeln([Object? obj = '']) {
+    write(encoding.encode('$obj$lineTerminator'));
+  }
 }

--- a/node_io/pubspec.yaml
+++ b/node_io/pubspec.yaml
@@ -1,6 +1,6 @@
 name: node_io
 description: Like dart:io but with Node.js.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/pulyaevskiy/node-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 


### PR DESCRIPTION
I'm unable to run the tests here directly since they depend on `build_node_compilers`, which is broken on recent Dart releases, but I've confirmed that all of the Sass migrator's tests pass with these changes on both Dart 3.3 and 3.4.